### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ is quite short, and so is its index. So to fill this sample with some real text,
 let´s elaborate on some aspects of a hand picked #index[Hand Picked] index. So, "hand
 picked" means, the entries #index[Entries] in the index are carefully chosen by the
 author(s) of the document to point the reader, who is interested in a specific topic
-within the documents domain #index[Domain], to the right spot #index[Spot]. Thats, how
+within the documents domain #index[Domain], to the right spot #index[Spot]. That's, how
 it should be; and it is quite different to what is done in this sample text, where the
 objective #index-main[Objective] was to put many different index markers
 #index[Markers] into a small text, because a sample should be as brief as possible,

--- a/sample-usage.typ
+++ b/sample-usage.typ
@@ -61,7 +61,7 @@ breaking changes #index[Breaking Changes] in its next iteration.
     #import "./in-dexter.typ": *
 ```
 
-The package is also available via Typst's build-in Package Manager:
+The package is also available via Typst's built-in Package Manager:
 
 ```typ
     #import "@preview/in-dexter:0.6.1": *
@@ -77,7 +77,7 @@ is available on GitHub.
 // This marks the start of the range for the Entry-Key "Entries"
 #index(indexType: indexTypes.Start)[Entries]
 
-// This marks the start of the range for the Entry-Key "Entriy-Marker"
+// This marks the start of the range for the Entry-Key "Entry-Marker"
 #index(indexType: indexTypes.Start)[Entry-Marker]
 
 We have marked several words to be included in an index page. The markup for the entry
@@ -182,14 +182,14 @@ index page. It can contain rich content, like math expressions:
 #indexMath(display: [$cal(T)^n$-set], "Aa-set4")
 
 Note that display may be ignored, if entries with the same entry key are defined
-beforehand. The first occurance of an entry defines the display of all other entries with
+beforehand. The first occurrence of an entry defines the display of all other entries with
 that entry key.
 
 
 === Advanced entries
 
 Simple math expressions can be used as entry key, like the following sample, where we also
-provide an initial parameter to put sort the entry unter "t" in the index:
+provide an initial parameter to put sort the entry under "t" in the index:
 
 ```typ
     #indexMath(initial: "t")[$t$-tuple]


### PR DESCRIPTION
Found via `codespell -S *.pdf -L ist` and `typos --hidden --format brief`