### PR TITLE
Add fct param to customize letter section title style.

### DIFF
--- a/in-dexter.typ
+++ b/in-dexter.typ
@@ -404,6 +404,7 @@ let rendered-pages = {
       set par(first-line-indent: 0pt, spacing: 0.65em, hanging-indent: 1em)
       body
   },
+  section_title_style: k => heading(level: 2, numbering: none, outlined: false, k)
 ) = (
   context {
     surround({
@@ -426,7 +427,7 @@ let rendered-pages = {
 
       for initial in initials.keys().sorted() {
         let letter = initials.at(initial)
-        heading(level: 2, numbering: none, outlined: false, letter)
+        section_title_style(letter)
         let entry = register.at(letter)
         // sort entries
         for idx in entry.keys().sorted(key: sort-order) {

--- a/sample-usage.typ
+++ b/sample-usage.typ
@@ -632,3 +632,79 @@ Here we explicitly select only the Math index.
     use-bang-grouping: true,
   )
 ]
+
+#pagebreak()
+
+== Customize letter section
+
+You can customize the look of the letter section/heading using a function:
+
+```typst
+#let my_section_title_style(letter) = {
+  set align(center + horizon)
+  set text(weight: "bold")
+  block(width: 100%, height: 1.5em, fill: blue.transparentize(50%), radius: 5pt)[
+    #letter
+  ]
+}
+
+#columns(3)[
+  #make-index(
+    section_title_style: my_section_title_style
+  )
+]
+```
+
+Here's the result:
+
+#let my_section_title_style(letter) = {
+  set align(center + horizon)
+  set text(weight: "bold")
+  block(width: 100%, height: 1.5em, fill: blue.transparentize(50%), radius: 5pt, breakable: false)[
+    #letter
+  ]
+}
+
+#columns(3)[
+  #make-index(
+    section_title_style: my_section_title_style
+  )
+]
+
+The default function is a level 2 heading:
+
+```typst
+#heading(level: 2, numbering: none, outlined: false, letter)
+```
+
+So you could also customize it by wrapping `make-index()` and redefining level 2 heading:
+
+```typst
+#let custom_index = {
+  show heading.where(level: 2): it => {
+    set text(fill: red)
+    block(it.body)
+  }
+  columns(3)[
+    #make-index(
+    )
+  ]
+}
+
+#custom_index
+```
+
+Here's the result:
+
+#let custom_index = {
+  show heading.where(level: 2): it => {
+    set text(fill: red)
+    block(it.body)
+  }
+  columns(3)[
+    #make-index(
+    )
+  ]
+}
+
+#custom_index


### PR DESCRIPTION
Hi,

First: thank you for this great package!

This pull request add a parameter to `make-index` to customize the section titles in the index.

It might be a bit overkill, because as I said in the doc, a wrapper of `make-index` can also be done with a show rule on level 2 heading.

I let the level 2 heading function as the default function for this new parameter.

Tell me what you think.

Best regards.